### PR TITLE
TST: Initial CI setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*~
+*.pyc
+*.pyo
+build/
+dist/
+*.egg-info/
+__pycache__/
+.cache/
+lib/calcos/version.py

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ bc0.build_cmds = ["python setup.py egg_info"]
 bc1 = utils.copy(bc0)
 bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
-bc1.env_vars = 'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/scsb-calcos']
+bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/scsb-calcos']
 bc1.build_cmds = ["conda config --add channels http://ssb.stsci.edu/astroconda",
                   "conda install -q -y ci-watson",
                   "python setup.py install"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,24 @@
+// Obtain files from source control system.
+if (utils.scm_checkout()) return
+
+// Define each build configuration, copying and overriding values as necessary.
+bc0 = new BuildConfig()
+bc0.nodetype = "linux-stable"
+bc0.name = "egg"
+bc0.build_cmds = ["python setup.py egg_info"]
+
+bc1 = utils.copy(bc0)
+bc1.name = "release"
+// Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
+bc1.env_vars = 'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/scsb-calcos']
+bc1.build_cmds = ["conda config --add channels http://ssb.stsci.edu/astroconda",
+                  "conda install -q -y ci-watson",
+                  "python setup.py install"]
+// TODO: Enable this when test is added
+// bc1.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata -v"]
+bc1.failedUnstableThresh = 1
+bc1.failedFailureThresh = 6
+
+// Iterate over configurations that define the (distibuted) build matrix.
+// Spawn a host of the given nodetype for each combination and run in parallel.
+utils.run([bc0, bc1])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
 bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.build_cmds = ["conda config --add channels http://ssb.stsci.edu/astroconda",
-                  "conda install -q -y numpy",
+                  "conda install -q -y numpy stsci.tools",
                   "pip install ci-watson",
                   "python setup.py install"]
 bc1.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata -v"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,8 +15,7 @@ bc1.build_cmds = ["conda config --add channels http://ssb.stsci.edu/astroconda",
                   "conda install -q -y numpy",
                   "pip install ci-watson",
                   "python setup.py install"]
-// TODO: Enable this when test is added
-// bc1.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata -v"]
+bc1.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata -v"]
 bc1.failedUnstableThresh = 1
 bc1.failedFailureThresh = 6
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
 bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/scsb-calcos']
 bc1.build_cmds = ["conda config --add channels http://ssb.stsci.edu/astroconda",
+                  "conda install -q -y numpy",
                   "pip install ci-watson",
                   "python setup.py install"]
 // TODO: Enable this when test is added

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
 bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/scsb-calcos']
 bc1.build_cmds = ["conda config --add channels http://ssb.stsci.edu/astroconda",
-                  "conda install -q -y ci-watson",
+                  "pip install ci-watson",
                   "python setup.py install"]
 // TODO: Enable this when test is added
 // bc1.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata -v"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ bc0.build_cmds = ["python setup.py egg_info"]
 bc1 = utils.copy(bc0)
 bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
-bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/scsb-calcos']
+bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.build_cmds = ["conda config --add channels http://ssb.stsci.edu/astroconda",
                   "conda install -q -y numpy",
                   "pip install ci-watson",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -6,7 +6,7 @@ if (utils.scm_checkout(['skip_disable':true])) return
 bc = new BuildConfig()
 bc.nodetype = "RHEL-6"
 bc.name = "release"
-bc.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/scsb-calcos',
+bc.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory',
                'lref=/grp/hst/cdbs/lref/']
 bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
 bc.conda_packages = ['python=3.6',

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -10,7 +10,8 @@ bc.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory',
                'lref=/grp/hst/cdbs/lref/']
 bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
 bc.conda_packages = ['python=3.6',
-                     'numpy']
+                     'numpy',
+                     'stsci.tools']
 bc.build_cmds = ["pip install ci-watson",
                  "python setup.py install"]
 bc.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata --slow -v"]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -9,9 +9,9 @@ bc.name = "release"
 bc.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/scsb-calcos',
                'lref=/grp/hst/cdbs/lref/']
 bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
-bc.conda_packages = ['python=3.6',
-                     'ci-watson']
-bc.build_cmds = ["python setup.py install"]
+bc.conda_packages = ['python=3.6']
+bc.build_cmds = ["pip install ci-watson",
+                 "python setup.py install"]
 bc.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata --slow -v"]
 bc.failedUnstableThresh = 1
 bc.failedFailureThresh = 6

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -9,7 +9,8 @@ bc.name = "release"
 bc.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/scsb-calcos',
                'lref=/grp/hst/cdbs/lref/']
 bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
-bc.conda_packages = ['python=3.6']
+bc.conda_packages = ['python=3.6',
+                     'numpy']
 bc.build_cmds = ["pip install ci-watson",
                  "python setup.py install"]
 bc.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata --slow -v"]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -1,0 +1,21 @@
+// Obtain files from source control system.
+// [skip ci] and [ci skip] have no effect here.
+if (utils.scm_checkout(['skip_disable':true])) return
+
+// Run nightly tests, which include the slow ones.
+bc = new BuildConfig()
+bc.nodetype = "RHEL-6"
+bc.name = "release"
+bc.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/scsb-calcos',
+               'lref=/grp/hst/cdbs/lref/']
+bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
+bc.conda_packages = ['python=3.6',
+                     'ci-watson']
+bc.build_cmds = ["python setup.py install"]
+bc.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata --slow -v"]
+bc.failedUnstableThresh = 1
+bc.failedFailureThresh = 6
+
+// Iterate over configurations that define the (distibuted) build matrix.
+// Spawn a host of the given nodetype for each combination and run in parallel.
+utils.run([bc])

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# CALCOS
+
+[![Jenkins CI](https://ssbjenkins.stsci.edu/job/STScI/job/calcos/job/master/badge/icon)](https://ssbjenkins.stsci.edu/job/STScI/job/calcos/job/master/)
+
+Calibration software for HST/COS.
+
+Nightly regression test results are available only from within the STScI
+network at this time.
+https://boyle.stsci.edu:8081/job/RT/job/calcos/test_results_analyzer/

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,3 +43,7 @@ setup_hooks =
 [tool:pytest]
 minversion = 3.0
 norecursedirs = build doc/build src
+
+[flake8]
+# E265: block comment should start with '#'
+ignore = E265

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,8 @@ pre-hook.numpy-extension-hook = stsci.distutils.hooks.numpy_extension_hook
 [global]
 setup_hooks =
 	stsci.distutils.hooks.use_packages_root
-	stsci.distutils.hooks.tag_svn_revision
 	stsci.distutils.hooks.version_setup_hook
 
+[tool:pytest]
+minversion = 3.0
+norecursedirs = build doc/build src

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ except ImportError:
 
 setup(
     setup_requires=['d2to1>=0.2.5', 'stsci.distutils>=0.3.2'],
+    tests_require=['pytest'],
     d2to1=True,
     use_2to3=False,
     zip_safe=False

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -23,9 +23,9 @@ def calref_from_image(input_image):
     # NOTE: Add additional mapping as needed.
     # Map mandatory CRDS reference file for instrument/detector combo.
     # This is for file not tied to any particular *CORR or used throughout.
-    #det_lookup = {
-    #    ('COS', 'FUV'): [],
-    #    ('COS', 'NUV'): []}
+    det_lookup = {
+        ('COS', 'FUV'): ['PROFTAB', 'SPWCSTAB'],
+        ('COS', 'NUV'): []}
 
     # NOTE: Add additional mapping as needed.
     # Map *CORR to associated CRDS reference file.
@@ -50,16 +50,15 @@ def calref_from_image(input_image):
         'WALKCORR': ['WALKTAB']}
 
     hdr = fits.getheader(input_image, ext=0)
-    #ref_files = ref_from_image(
-    #    input_image, det_lookup[(hdr['INSTRUME'], hdr['DETECTOR'])])
+    ref_files = ref_from_image(
+        input_image, det_lookup[(hdr['INSTRUME'], hdr['DETECTOR'])])
 
     for step in corr_lookup:
         # Not all images have the CORR step and it is not always on.
         if (step not in hdr) or (hdr[step].strip().upper() != 'PERFORM'):
             continue
 
-        #ref_files += ref_from_image(input_image, corr_lookup[step])
-        ref_files = ref_from_image(input_image, corr_lookup[step])
+        ref_files += ref_from_image(input_image, corr_lookup[step])
 
     return list(set(ref_files))  # Remove duplicates
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,221 @@
+"""CALCOS regression test helpers."""
+
+import os
+import sys
+
+import pytest
+from ci_watson.artifactory_helpers import get_bigdata
+from ci_watson.hst_helpers import raw_from_asn, ref_from_image, download_crds
+
+from astropy.io import fits
+from astropy.io.fits import FITSDiff
+
+__all__ = ['calref_from_image', 'BaseCOS']
+
+
+def calref_from_image(input_image):
+    """
+    Return a list of reference filenames, as defined in the primary
+    header of the given input image, necessary for calibration; i.e.,
+    only those associated with ``*CORR`` set to ``PERFORM`` will be
+    considered.
+    """
+    # NOTE: Add additional mapping as needed.
+    # Map mandatory CRDS reference file for instrument/detector combo.
+    # This is for file not tied to any particular *CORR or used throughout.
+    #det_lookup = {
+    #    ('COS', 'FUV'): [],
+    #    ('COS', 'NUV'): []}
+
+    # NOTE: Add additional mapping as needed.
+    # Map *CORR to associated CRDS reference file.
+    corr_lookup = {
+        'BADTCORR': ['BADTTAB'],
+        'TEMPCORR': ['BRFTAB'],
+        'GEOCORR': ['GEOFILE'],
+        'DGEOCORR': ['DGEOFILE'],
+        'YWLKCORR': ['YWLKFILE'],
+        'XWLKCORR': ['XWLKFILE'],
+        'DEADCORR': ['DEADTAB'],
+        'PHACORR': ['PHATAB', 'PHAFILE'],
+        'FLATCORR': ['FLATFILE'],
+        'WAVECORR': ['LAMPTAB', 'DISPTAB', 'TWOZXTAB', 'XTRACTAB'],
+        'BRSTCORR': ['BRSTTAB'],
+        'TRCECORR': ['TRACETAB'],
+        'ALGNCORR': ['TWOZXTAB'],
+        'DQICORR': ['SPOTTAB', 'TRACETAB', 'BPIXTAB', 'GSAGTAB'],
+        'X1DCORR': ['WCPTAB', 'TWOZXTAB', 'XTRACTAB'],
+        'BACKCORR': ['TWOZXTAB', 'XTRACTAB'],
+        'FLUXCORR': ['FLUXTAB', 'TDSTAB', 'PHOTTAB'],
+        'WALKCORR': ['WALKTAB']}
+
+    hdr = fits.getheader(input_image, ext=0)
+    #ref_files = ref_from_image(
+    #    input_image, det_lookup[(hdr['INSTRUME'], hdr['DETECTOR'])])
+
+    for step in corr_lookup:
+        # Not all images have the CORR step and it is not always on.
+        if (step not in hdr) or (hdr[step].strip().upper() != 'PERFORM'):
+            continue
+
+        #ref_files += ref_from_image(input_image, corr_lookup[step])
+        ref_files = ref_from_image(input_image, corr_lookup[step])
+
+    return list(set(ref_files))  # Remove duplicates
+
+
+# Base class for actual tests.
+# NOTE: Named in a way so pytest will not pick them up here.
+# NOTE: bigdata marker requires TEST_BIGDATA environment variable to
+#       point to a valid big data directory, whether locally or on Artifactory.
+# NOTE: envopt would point tests to "dev" or "stable".
+# NOTE: _jail fixture ensures each test runs in a clean tmpdir.
+@pytest.mark.bigdata
+@pytest.mark.usefixtures('_jail', 'envopt')
+class BaseCOS:
+    # Timeout in seconds for file downloads.
+    timeout = 30
+
+    instrument = 'cos'
+    ignore_keywords = ['DATE', 'CAL_VER']
+
+    # To be defined by test class in actual test modules.
+    detector = ''
+
+    @pytest.fixture(autouse=True)
+    def setup_class(self, envopt):
+        """
+        Class-level setup that is done at the beginning of the test.
+
+        Parameters
+        ----------
+        envopt : {'dev', 'stable'}
+            This is a ``pytest`` fixture that defines the test
+            environment in which input and truth files reside.
+
+        """
+        # Since CALCOS still runs in PY2, need to check here because
+        # tests can only run in PY3.
+        if sys.version_info < (3, ):
+            raise SystemError('tests can only run in Python 3')
+
+        self.env = envopt
+
+    def get_input_file(self, filename):
+        """
+        Copy input file (ASN, RAW, etc) into the working directory.
+        If ASN is given, RAW files in the ASN table is also copied.
+        The associated CRDS reference files are also copied or
+        downloaded, if necessary.
+
+        Data directory layout for CALCOS::
+
+            detector/
+                input/
+                truth/
+
+        Parameters
+        ----------
+        filename : str
+            Filename of the ASN/RAW/etc to copy over, along with its
+            associated files.
+
+        """
+        # Copy over main input file.
+        dest = get_bigdata('scsb-calcos', self.env, self.detector, 'input',
+                           filename)
+
+        # TODO: This logic was based on ONE FUV test. Please revise as needed.
+        if filename.endswith('_asn.fits'):
+            all_raws = raw_from_asn(filename, '_rawtag_a.fits')
+            all_raws += raw_from_asn(filename, '_rawtag_b.fits')
+            for raw in all_raws:  # Download RAWs in ASN.
+                get_bigdata('scsb-calcos', self.env, self.detector, 'input',
+                            raw)
+            for raw in raw_from_asn(filename, '_spt.fits'):  # Input SPTs
+                get_bigdata('scsb-calcos', self.env, self.detector, 'input',
+                            raw)
+        else:
+            all_raws = [filename]
+
+        first_pass = ('JENKINS_URL' in os.environ and
+                      'ssbjenkins' in os.environ['JENKINS_URL'])
+
+        for raw in all_raws:
+            ref_files = calref_from_image(raw)
+
+            for ref_file in ref_files:
+                # Special reference files that live with inputs.
+                if ('$' not in ref_file and
+                        os.path.basename(ref_file) == ref_file):
+                    get_bigdata('scsb-calcos', self.env, self.detector,
+                                'input', ref_file)
+                    continue
+
+                # Jenkins cannot see Central Storage on push event,
+                # and somehow setting, say, jref to "." does not work anymore.
+                # So, we need this hack.
+                if '$' in ref_file and first_pass:
+                    first_pass = False
+                    if not os.path.isdir('/grp/hst/cdbs'):
+                        ref_path = os.path.dirname(dest) + os.sep
+                        var = ref_file.split('$')[0]
+                        os.environ[var] = ref_path  # hacky hack hack
+
+                # Download reference files, if needed only.
+                download_crds(ref_file, timeout=self.timeout)
+
+    def compare_outputs(self, outputs, atol=0, rtol=1e-7, raise_error=True,
+                        ignore_keywords_overwrite=None):
+        """
+        Compare CALXXX output with "truth" using ``fitsdiff``.
+
+        Parameters
+        ----------
+        outputs : list of tuple
+            A list of tuples, each containing filename (without path)
+            of CALXXX output and truth, in that order. Example::
+
+                [('output1.fits', 'truth1.fits'),
+                 ('output2.fits', 'truth2.fits'),
+                 ...]
+
+        atol, rtol : float
+            Absolute and relative tolerance for data comparison.
+
+        raise_error : bool
+            Raise ``AssertionError`` if difference is found.
+
+        ignore_keywords_overwrite : list of str or `None`
+            If not `None`, these will overwrite
+            ``self.ignore_keywords`` for the calling test.
+
+        Returns
+        -------
+        report : str
+            Report from ``fitsdiff``.
+            This is part of error message if ``raise_error=True``.
+
+        """
+        all_okay = True
+        creature_report = ''
+
+        if ignore_keywords_overwrite is None:
+            ignore_keywords = self.ignore_keywords
+        else:
+            ignore_keywords = ignore_keywords_overwrite
+
+        for actual, desired in outputs:
+            desired = get_bigdata('scsb-calcos', self.env, self.detector,
+                                  'truth', desired)
+            fdiff = FITSDiff(actual, desired, rtol=rtol, atol=atol,
+                             ignore_keywords=ignore_keywords)
+            creature_report += fdiff.report()
+
+            if not fdiff.identical and all_okay:
+                all_okay = False
+
+        if not all_okay and raise_error:
+            raise AssertionError(os.linesep + creature_report)
+
+        return creature_report

--- a/tests/test_fuv_timetag.py
+++ b/tests/test_fuv_timetag.py
@@ -1,0 +1,41 @@
+"""Tests for COS/FUV timetag."""
+
+#import pytest
+
+import calcos
+from helpers import BaseCOS
+
+
+# TODO: Mark this as slow when there are faster tests added for CI tests
+#       so that this only runs in nightly tests.
+#@pytest.mark.slow
+class TestFUVTimetag(BaseCOS):
+    detector = 'fuv'
+
+    def test_fuv_timetag_1(self):
+        """
+        FUV COS regression test #1
+        """
+        asn_file = 'lckg01070_asn.fits'
+
+        # Prepare input files.
+        self.get_input_file(asn_file)
+
+        # Run CALCOS
+        calcos.calcos(asn_file)
+
+        # Compare results.
+        # The first outroot is the output from whole ASN,
+        # the rest are individual members.
+        outroots = ['lckg01070', 'lckg01czq', 'lckg01d4q', 'lckg01d9q',
+                    'lckg01dcq']
+        outputs = []
+        for sfx in ('x1dsum', 'x1dsum1', 'x1dsum2', 'x1dsum3', 'x1dsum4'):
+            fname = '{}_{}.fits'.format(outroots[0], sfx)
+            outputs.append((fname, fname))
+        for outroot in outroots[1:]:
+            for sfx in ('corrtag_a', 'corrtag_b', 'counts_a', 'counts_b',
+                        'flt_a', 'flt_b', 'lampflash', 'x1d'):
+                fname = '{}_{}.fits'.format(outroot, sfx)
+                outputs.append((fname, fname))
+        self.compare_outputs(outputs, rtol=3e-7)


### PR DESCRIPTION
Important note: Given that `ci-watson` only support Python 3, the tests here can only run in Python 3. There is no Python 2 support for CI testing.

Fix #29 

Close #18 

TODO:

- [x] Set up Artifactory data
- [x] Add test from Robert

Post-merge action items:

- [x] Open follow up issue to mark that test as slow in the future (see #39)
- [x] Ask @rendinam to enable nightly run using `JenkinsRT` (will run daily at 10 AM, link given in README of this PR)
- [ ] Disable `pandokia` test that is `stsci_python/calcos/fuv_timetag_1`
- [ ] Give `calcos` transition a smiley face