### PR TITLE
Create "calcos" entrypoint to main()

### DIFF
--- a/calcos/calcos
+++ b/calcos/calcos
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-from __future__ import division         # confidence high
-import calcos
-import sys
-
-if __name__ == '__main__':
-    calcos.main(sys.argv[1:])
-

--- a/calcos/calcos.py
+++ b/calcos/calcos.py
@@ -45,7 +45,7 @@ BAD_APER_MISSING_ROW_EXCEPTION = 16
 # will be set to True.
 raw_input_trailer = False
 
-def main(args):
+def main(args=sys.argv[1:]):
     """Check arguments and call calcos.
 
     This driver interprets command-line arguments and calls calcos for

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'astropy>=1.1.1',
         'numpy>=1.10.1',
         'scipy>=0.14',
+        'stsci.tools>=3.5',
     ],
     extras_require={
         'docs': [
@@ -66,6 +67,11 @@ setup(
             include_dirs=INCLUDES,
         ),
     ],
+    entry_points={
+        'console_scripts': {
+            'calcos = calcos:main',
+        },
+    },
     author='Phil Hodge, Robert Jedrzejewski',
     author_email='help@stsci.edu',
     description='Calibration software for COS (Cosmic Origins Spectrograph)',


### PR DESCRIPTION
@stscirij  : Sorry, I missed the `scripts = ` entry in `setup.cfg` when I was working on this.

This removes the original shell script and lets `setuptools` create `[..]/bin/calcos` itself (https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation)

Fixes: #33 

