### PR TITLE
Update version of Python and dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ if (utils.scm_checkout()) return
 
 // Define each build configuration, copying and overriding values as necessary.
 bc0 = new BuildConfig()
-bc0.nodetype = "python3.6"
+bc0.nodetype = "python3.7"
 bc0.name = "egg"
 bc0.build_cmds = ["pip install numpy",
                   "python setup.py egg_info"]
@@ -12,11 +12,11 @@ bc1 = utils.copy(bc0)
 bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
 bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
-bc1.conda_channels = ['http://ssb.stsci.edu/astroconda']
-bc1.conda_packages = ['python=3.7',
-                      'requests',
-                      'numpy',
-                      'stsci.tools']
+// bc1.conda_packages = ['python=3.7',
+//                      'requests',
+//                      'numpy',
+//                      'stsci.tools']
+bc1.build_cmds = ["pip install numpy>=1.20"]
 bc1.build_cmds = ["pip install -e .[test]"]
 bc1.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata -v"]
 bc1.failedUnstableThresh = 1
@@ -31,4 +31,4 @@ bc2.build_cmds = ["pip install -e .[test]",
 
 // Iterate over configurations that define the (distibuted) build matrix.
 // Spawn a host of the given nodetype for each combination and run in parallel.
-utils.run([bc0, bc1, bc2])
+utils.run([bc0, bc1])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,13 +22,13 @@ bc1.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --
 bc1.failedUnstableThresh = 1
 bc1.failedFailureThresh = 6
 
-// Run with astropy dev and Python 3.7
+// Run with astropy dev and Python 3.8
 bc2 = utils.copy(bc1)
 bc2.name = "dev"
-bc2.conda_packages[0] = "python=3.7"
+bc2.conda_packages[0] = "python=3.8"
 bc2.build_cmds = ["pip install -e .[test]",
                   "pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps"]
 
 // Iterate over configurations that define the (distibuted) build matrix.
 // Spawn a host of the given nodetype for each combination and run in parallel.
-utils.run([bc0, bc1])
+utils.run([bc0, bc1, bc2])

--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,10 @@ setup(
     use_scm_version={'write_to': 'calcos/version.py'},
     setup_requires=['setuptools_scm'],
     install_requires=[
-        'astropy>=1.1.1',
-        'numpy>=1.10.1',
-        'scipy>=0.14',
-        'stsci.tools>=3.5',
+        'astropy',
+        'numpy',
+        'scipy',
+        'stsci.tools',
     ],
     extras_require={
         'docs': [


### PR DESCRIPTION
The Jenkins regression tests are failing because of a version mismatch.
They are setup to run with Python 3.6 but calcos requires the latest scipy, which in turn requires Python 3.7.
This PR updates the version of Python used in RT and updates the other calcos dependencies.