### PR TITLE
Reverting the two commits to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from fnmatch import fnmatch
 from setuptools import setup, find_packages, Extension
 from numpy import get_include as numpy_includes
 
-print('test')
 
 def c_sources(parent):
     sources = []

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ from fnmatch import fnmatch
 from setuptools import setup, find_packages, Extension
 from numpy import get_include as numpy_includes
 
+print('test')
+
 def c_sources(parent):
     sources = []
     for root, _, files in os.walk(parent):


### PR DESCRIPTION
These changes were intended as a demonstration for my fork, not the spacetelescope main repo. 

I reverted the two commits and a git status produces:
On branch undo_commits
nothing to commit, working tree clean

So, no files should have changed because I removed the print statement line I had added in, but the log should show that the changes were reverted. I think?