### PR TITLE
Fix problems with regression tests

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -24,10 +24,10 @@ bc.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --b
 bc.failedUnstableThresh = 1
 bc.failedFailureThresh = 6
 
-// Astropy dev and Python 3.7
+// Astropy dev and Python 3.8 (astropy dev requires python >= 3.8)
 bc1 = utils.copy(bc)
 bc1.name = "dev"
-bc1.conda_packages[0] = "python=3.7"
+bc1.conda_packages[0] = "python=3.8"
 bc1.build_cmds = ["pip install ci-watson",
                   "pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps",
                  "python setup.py install"]

--- a/tests/test_dark_fuva.py
+++ b/tests/test_dark_fuva.py
@@ -35,5 +35,6 @@ class TestFUVADark(BaseCOS):
             for sfx in ('corrtag_a', 'corrtag_b', 'counts_a', 'counts_b',
                         'flt_a', 'flt_b'):
                 fname = '{}_{}.fits'.format(outroot, sfx)
-                outputs.append((fname, fname))
+                comparison_name = 'ref_' + fname
+                outputs.append((fname, comparison_name))
         self.compare_outputs(outputs, rtol=3e-7)

--- a/tests/test_fuv_timetag.py
+++ b/tests/test_fuv_timetag.py
@@ -35,10 +35,12 @@ class TestFUVTimetag(BaseCOS):
         outputs = []
         for sfx in ('x1dsum', 'x1dsum1', 'x1dsum2', 'x1dsum3', 'x1dsum4'):
             fname = '{}_{}.fits'.format(outroots[0], sfx)
-            outputs.append((fname, fname))
+            comparison_name = 'ref_' + fname
+            outputs.append((fname, comparison_name))
         for outroot in outroots[1:]:
             for sfx in ('corrtag_a', 'corrtag_b', 'counts_a', 'counts_b',
                         'flt_a', 'flt_b', 'lampflash', 'x1d'):
                 fname = '{}_{}.fits'.format(outroot, sfx)
-                outputs.append((fname, fname))
+                comparison_name = 'ref_' + fname
+                outputs.append((fname, comparison_name))
         self.compare_outputs(outputs, rtol=3e-7)


### PR DESCRIPTION
Require Python 3.8 for testing with astropy dev
Change comparison file names in tests
Tests are failing because Jenkins setup is using Python 3.7 and astropy dev requires python
>= 3.8
Also current tests automatically pass if the comparison file name is the same as the test filename, so
they need to have a different name.  I have uploaded new truth files to artifactory with the new name, but they
were made using calcos 3.3.10 so the x1d files will fail in the fuv_timetag_1 test.  I will upload new files soon