### PR TITLE
Add warning when calibrating rawtags

### DIFF
--- a/calcos/calcos.py
+++ b/calcos/calcos.py
@@ -2845,6 +2845,19 @@ class Calibration(object):
                obs.exp_type == EXP_CALIBRATION or \
                obs.exp_type == EXP_ACQ_IMAGE:
                 obs.openTrailer()
+                if not self.assoc.asn_info['exists'] and not obs.info['tagflash'] and \
+                   obs.info["obstype"] == "SPECTROSCOPIC":
+                    nowavecalwarning = "\nCAUTION: You are running CalCOS with a "
+                    nowavecalwarning += "rawtag or corrtag file\nthat does not "
+                    nowavecalwarning += "contain simultaneous lamp data instead "
+                    nowavecalwarning += "of using\nan association (asn) file as "
+                    nowavecalwarning += "an input. No wavelength correction\nwill "
+                    nowavecalwarning += "be applied and your wavelength "
+                    nowavecalwarning += "calibration will be wrong.\nIf you wish "
+                    nowavecalwarning += "to create a custom asn file for use with "
+                    nowavecalwarning += "your data,\nplease refer to Chapter 3 of "
+                    nowavecalwarning += "the COS Data Handbook."
+                    cosutil.printMsg(nowavecalwarning)
                 try:
                     self.basicCal(obs.filenames,
                                   obs.info, obs.switches, obs.reffiles)


### PR DESCRIPTION
Added warning for users who calibrate individual rawtags without tagflashes, their wavelength calibration will be off.
Implements COSPIP-101