### PR TITLE
Use oldest numpy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "setuptools>=38.2.5",
-    "setuptools_scm",
+    "setuptools>=42.0",
+    "setuptools_scm[toml]>=3.4",
     "wheel",
-    "numpy"
+    "oldest-supported-numpy",
 ]


### PR DESCRIPTION
This is the recommended way to get numpy installed before building the package.
Also it makes it consistent with other packages maintained by STScI.