### PR TITLE
Calcos Version 3.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ requires = [
     "setuptools>=42.0",
     "setuptools_scm[toml]>=3.4",
     "wheel",
-    "oldest-supported-numpy",
+    "numpy",
 ]


### PR DESCRIPTION
Back out oldest-supported-numpy from pyproject.toml