### PR TITLE
Fix calcos issue in 3.4.0 when input science file has empty event list

### DIFF
--- a/calcos/calcos.py
+++ b/calcos/calcos.py
@@ -2640,6 +2640,10 @@ class Observation(object):
             cosutil.printMsg("Cannot get events from data extension")
             return False
         f1.close()
+        if len(events) == 0:
+            if debug:
+                cosutil.printMsg("Don't add simulated wavecal as no events recorded")
+            return False
         events_duration = time[-1] - time[0]
         mintime = self.getMinTime(wcp_info)
         if mintime is None:


### PR DESCRIPTION
CheckforAddSimulatedWavecal tries to calculate the exposure duration by calculating the difference between the time of the last and first events.  This causes an index error if the event list is empty.  This fix will trap the case of zero events and proceed normally.  Products are created, with empty data extensions if events are absent.