### PR TITLE
replace usages of `np.int` with `int`

### DIFF
--- a/calcos/cosutil.py
+++ b/calcos/cosutil.py
@@ -3751,7 +3751,7 @@ def errGehrels(counts):
         (The lower error estimate for counts,
          the upper error estimate for counts)
     """
-    icounts = (counts + .5).astype(np.int)
+    icounts = (counts + .5).astype(int)
     upper = (1. + np.sqrt(icounts + 0.75))
     lower = np.where(icounts > 0., Gehrels_lower(icounts), 0.)
     return (lower.astype(np.float32), upper.astype(np.float32))


### PR DESCRIPTION
This PR addresses Numpy deprecations in `numpy>=1.24.0`