### PR TITLE
refactor workflow to install from build configuration and use `pytest` and `tox`

### DIFF
--- a/.github/workflows/python_testing.yml
+++ b/.github/workflows/python_testing.yml
@@ -10,8 +10,6 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-    - cron: '00 00 * * *'  # every day at midnight
 
 jobs:
   check:

--- a/.github/workflows/python_testing.yml
+++ b/.github/workflows/python_testing.yml
@@ -15,19 +15,20 @@ on:
 
 jobs:
   check:
-    name: check code style
+    name: ${{ matrix.toxenv }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toxenv: [ check-style, check-build ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}
+          python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: 'setup.py'
-      - run: pip install flake8
-      - run: |
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          cache-dependency-path: 'tox.ini'
+      - run: pip install tox
+      - run: tox -e ${{ matrix.toxenv }}
   test:
     name: run tests (Python ${{ matrix.python }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -37,14 +38,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest,macos-latest ]
+        toxenv: [ test-xdist ]
         python: [ '3.8', '3.9', '3.10', '3.11' ]
+        os: [ ubuntu-latest,macos-latest ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'
-          cache-dependency-path: 'setup.py'
-      - run: pip install ".[test]" pytest-xdist
-      - run: pytest -n auto --slow
+          cache-dependency-path: 'tox.ini'
+      - run: pip install tox
+      - run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/python_testing.yml
+++ b/.github/workflows/python_testing.yml
@@ -16,6 +16,7 @@ jobs:
     name: ${{ matrix.toxenv }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         toxenv: [ check-style, check-build ]
     steps:

--- a/.github/workflows/python_testing.yml
+++ b/.github/workflows/python_testing.yml
@@ -5,64 +5,44 @@ name: CalCOS Pytest
 
 on:
   push:
-    branches: [ pytest ]
+    branches:
+      - master
   pull_request:
-    branches: [ pytest ]
   schedule:
     - cron: '00 00 * * *'  # every day at midnight
 
 jobs:
-  build:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runs-on }}
-    env: 
+  check:
+    name: check code style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: 'pip'
+          cache-dependency-path: 'setup.py'
+      - run: pip install flake8
+      - run: |
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  test:
+    name: run tests (Python ${{ matrix.python }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    env:
       TEST_BIGDATA: https://bytesalad.stsci.edu/artifactory
       lref: /grp/hst/cdbs/lref/
-      working-directory: ./
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: Python 3.10
-            runs-on: ubuntu-latest
-            python-version: '3.10'
-            toxenv: py310
-
-          - name: Python 3.9
-            runs-on: ubuntu-latest
-            python-version: 3.9
-            toxenv: py39
-            
-          - name: Python 3.8
-            runs-on: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38
-            
+        os: [ ubuntu-latest,macos-latest ]
+        python: [ '3.8', '3.9', '3.10', '3.11' ]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        pip install ci-watson
-        pip install astropy
-        pip install scipy
-        pip install matplotlib
-        pip install stsci.tools==4.0.0
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        # run all the unit tests.
-        python setup.py install
-        pytest tests/test_cosutil.py -v 
-      working-directory: ${{env.working-directory}}
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: 'pip'
+          cache-dependency-path: 'setup.py'
+      - run: pip install ".[test]" pytest-xdist
+      - run: pytest -n auto --slow

--- a/.github/workflows/python_testing.yml
+++ b/.github/workflows/python_testing.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
   schedule:
     - cron: '00 00 * * *'  # every day at midnight
 

--- a/.github/workflows/python_testing.yml
+++ b/.github/workflows/python_testing.yml
@@ -30,7 +30,7 @@ jobs:
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
   test:
-    name: run tests (Python ${{ matrix.python }}, ${{ matrix.os }})
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     env:
       TEST_BIGDATA: https://bytesalad.stsci.edu/artifactory
@@ -41,6 +41,10 @@ jobs:
         toxenv: [ test-xdist ]
         python: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest,macos-latest ]
+        include:
+          - toxenv: test-cov-xdist
+            os: ubuntu-latest
+            python: '3.11'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -50,3 +54,9 @@ jobs:
           cache-dependency-path: 'tox.ini'
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
+      - if: contains(matrix.toxenv, '-cov')
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          flags: unit
+          fail_ci_if_error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,4 @@ requires = [
     "wheel",
     "oldest-supported-numpy",
 ]
+build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,5 +8,6 @@ junit_family = xunit2
 
 [flake8]
 # E265: block comment should start with '#'
-ignore = E265
+# F821 undefined name
+ignore = E265,F821,F841
 exclude = setup.py,__init__.py

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,8 @@ setup(
     author='Phil Hodge, Robert Jedrzejewski',
     author_email='help@stsci.edu',
     description='Calibration software for COS (Cosmic Origins Spectrograph)',
+    long_description='README.md',
+    long_description_content_type='text/x-rst',
     url='https://github.com/spacetelescope/calcos',
     license='BSD',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -39,14 +39,14 @@ setup(
         'astropy>=5.0.4',
         'numpy',
         'scipy',
-        'stsci.tools',
+        'stsci.tools>=4.0.0',
     ],
     extras_require={
         'docs': [
             'sphinx',
         ],
         'test': [
-            'ci_watson',
+            'ci-watson',
             'pytest',
             'pytest-cov',
             'codecov',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,77 @@
+[tox]
+envlist =
+    check-{style,build}
+    test{,-pyargs,-warnings,-regtests,-cov}
+    build-{docs,dist}
+
+# tox environments are constructed with so-called 'factors' (or terms)
+# separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
+# will only take effect if that factor is included in the environment name. To
+# see a list of example environments that can be run, along with a description,
+# run:
+#
+#     tox -l -v
+#
+
+[testenv:check-style]
+description = check code style, e.g. with flake8
+skip_install = true
+deps =
+    flake8
+commands =
+    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics {posargs}
+    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics {posargs}
+
+[testenv:check-build]
+description = check build sdist/wheel and a strict twine check for metadata
+skip_install = true
+deps =
+    build
+    twine>=3.3
+commands =
+    python -m build .
+    twine check --strict dist/*
+
+[testenv]
+description =
+    run tests
+    warnings: treating warnings as errors
+    regtests: with --bigdata and --slow flags
+    cov: with coverage
+    xdist: using parallel processing
+passenv =
+    HOME
+    CRDS_*
+    CODECOV_*
+    TEST_BIGDATA
+    lref
+extras =
+    test
+deps =
+    cov: pytest-cov
+    xdist: pytest-xdist
+commands_pre =
+    pip freeze
+commands =
+    pytest --slow \
+    regtests: --bigdata \
+    cov: --cov --cov-report=xml \
+    warnings: -W error \
+    xdist: -n auto \
+    {posargs}
+
+[testenv:build-docs]
+description = invoke sphinx-build to build the HTML docs
+skip_install = true
+extras =
+    docs
+commands =
+    sphinx-build -W docs/source docs/_build
+
+[testenv:build-dist]
+description = build wheel and sdist
+skip_install = true
+deps =
+    build
+commands =
+    python -m build .

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     check-{style,build}
-    test{,-pyargs,-warnings,-regtests,-cov}
+    test{,-pyargs,-warnings,-regtests,-cov}-xdist
     build-{docs,dist}
 
 # tox environments are constructed with so-called 'factors' (or terms)


### PR DESCRIPTION
This PR refactors the workflow CI to run on push to `master` or on a pull request, and additionally uses `tox` to run lint / build checks before running tests with `pytest-xdist`.

<img width="285" alt="image" src="https://user-images.githubusercontent.com/16024299/209980396-99918dde-979f-4786-a078-40e93c67871d.png">

blocked by #217:
```
AttributeError: module 'numpy' has no attribute 'int'. Did you mean: 'inf'?
```