### PR TITLE
use nightly built wheels for `astropy`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ bc2 = utils.copy(bc1)
 bc2.name = "dev"
 bc2.conda_packages[0] = "python=3.8"
 bc2.build_cmds = ["pip install -e .[test]",
-                  "pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps",
+                  "pip install astropy>=0.0.dev0 --upgrade --no-deps",
                   "pip install pyyaml"]
 
 // Iterate over configurations that define the (distibuted) build matrix.

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -29,7 +29,7 @@ bc1 = utils.copy(bc)
 bc1.name = "dev"
 bc1.conda_packages[0] = "python=3.8"
 bc1.build_cmds = ["pip install -e .[test]",
-                  "pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps",
+                  "pip install astropy>=0.0.dev0 --upgrade --no-deps",
                   "pip install pyyaml"]
 
 // Iterate over configurations that define the (distributed) build matrix.


### PR DESCRIPTION
this PR attempts to solve the issue with building `astropy` in the Jenkins job (https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2Fcalcos/detail/calcos/1622/pipeline), by using the nightly-built dev wheels