### PR TITLE
remove usages of deprecated `codecov` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ test = [
     "ci-watson",
     "pytest",
     "pytest-cov",
-    "codecov",
 ]
 
 [build-system]


### PR DESCRIPTION
the `codecov` package is now deprecated and has been yanked from PyPI