### PR TITLE
Updated runners for building wheels in publish_to_pypi workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: spacetelescope/action-publish_to_pypi/build-wheel@master


### PR DESCRIPTION
Previous macos runner not available any more so process was hanging