### PR TITLE
Fix problem from formerly deprecated numpy behaviour now raising exception

### DIFF
--- a/tests/test_cosutil.py
+++ b/tests/test_cosutil.py
@@ -46,7 +46,7 @@ def test_get_table_exceptions():
     name = "getTable.fits"
     generate_fits_file(name)
     # truth = [tuple(ofd[1].data[3])]
-    t = np.ones(5)  # non-existent values
+    t = 1.0  # non-existent value
     with pytest.raises(MissingRowError):
         cosutil.getTable(name, {'Time': t}, exactly_one=True)
     # Cleanup


### PR DESCRIPTION
One unit test does a comparison between an array and scalar.  Before numpy 1.25, this raised a deprecation warning (need to use np.any() or np.all()).  With numpy 1.25, this is now an error.