### PR TITLE
Revert "move build configuration into `pyproject.toml` (#216)"

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-# flake8 does not support pyproject.toml (https://github.com/PyCQA/flake8/issues/234)
-
-[flake8]
-# E265: block comment should start with '#'
-# F821 undefined name
-extend-ignore = E265,F821,F841
-extend-exclude = setup.py,__init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,77 +1,8 @@
-[project]
-name = "calcos"
-description = "Calibration software for COS (Cosmic Origins Spectrograph)"
-requires-python = ">=3.8"
-authors = [
-    { name = "Phil Hodge" },
-    { name = "Robert Jedrzejewski" },
-]
-classifiers = [
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: C",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-]
-dependencies = [
-    "astropy>=5.0.4",
-    "numpy",
-    "scipy",
-    "stsci.tools>=4.0.0",
-]
-dynamic = [
-    "version",
-]
-
-[project.readme]
-file = "README.md"
-content-type = "text/markdown"
-
-[project.scripts]
-calcos = "calcos:main"
-
-[project.optional-dependencies]
-docs = [
-    "sphinx",
-    "stsci_rtd_theme",
-]
-test = [
-    "ci-watson",
-    "pytest",
-    "pytest-cov",
-]
-
 [build-system]
 requires = [
-    "setuptools>=61.2",
+    "setuptools>=42.0",
     "setuptools_scm[toml]>=3.4",
     "wheel",
     "oldest-supported-numpy",
 ]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools]
-include-package-data = false
-
-[tool.setuptools.packages.find]
-namespaces = false
-
-[tool.setuptools.package-data]
-calcos = [
-    "pars/*",
-    "*.help",
-]
-
-[tool.setuptools_scm]
-write_to = 'calcos/version.py'
-
-[tool.pytest.ini_options]
-minversion = "3.0"
-norecursedirs = [
-    "build",
-    "doc/build",
-    "src",
-]
-junit_family = "xunit2"
-
+build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[options]
+python_requires = >=3.8
+
+[tool:pytest]
+minversion = 3.0
+norecursedirs = build doc/build src
+junit_family = xunit2
+
+[flake8]
+# E265: block comment should start with '#'
+# F821 undefined name
+ignore = E265,F821,F841
+exclude = setup.py,__init__.py

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,8 @@
 
 import os
 from fnmatch import fnmatch
-
+from setuptools import setup, find_packages, Extension
 from numpy import get_include as numpy_includes
-from setuptools import setup, Extension
-
 
 def c_sources(parent):
     sources = []
@@ -32,12 +30,60 @@ PACKAGENAME = 'calcos'
 SOURCES = c_sources('src')
 INCLUDES = c_includes('src') + [numpy_includes()]
 
+
 setup(
+    name=PACKAGENAME,
+    use_scm_version={'write_to': 'calcos/version.py'},
+    setup_requires=['setuptools_scm'],
+    install_requires=[
+        'astropy>=5.0.4',
+        'numpy',
+        'scipy',
+        'stsci.tools>=4.0.0',
+    ],
+    extras_require={
+        'docs': [
+            'sphinx',
+        ],
+        'test': [
+            'ci-watson',
+            'pytest',
+            'pytest-cov',
+            'codecov',
+        ],
+    },
+    packages=find_packages(),
+    package_data={
+        PACKAGENAME: [
+            'pars/*',
+            '*.help',
+        ],
+    },
     ext_modules=[
         Extension(
             PACKAGENAME + '.ccos',
             sources=SOURCES,
             include_dirs=INCLUDES,
         ),
+    ],
+    entry_points={
+        'console_scripts': {
+            'calcos = calcos:main',
+        },
+    },
+    author='Phil Hodge, Robert Jedrzejewski',
+    author_email='help@stsci.edu',
+    description='Calibration software for COS (Cosmic Origins Spectrograph)',
+    long_description='README.md',
+    long_description_content_type='text/x-rst',
+    url='https://github.com/spacetelescope/calcos',
+    license='BSD',
+    classifiers=[
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: C',
+        'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )


### PR DESCRIPTION
This reverts commit 9af631fa0c0dcf475b0bbcc59545b2c81a2468d8 due to suspected involvement in https://jira.stsci.edu/browse/SPB-1432

It appears that the HCALDP build was explicitly relying on `calcos` to provide `pytest` as a dependency, and since `calcos`'s metadata is not parsed correctly for some reason, and the only difference seems to be using PEP621 (`setup.py` -> `pyproject.toml`), we are reverting the PEP621 change for now.