### PR TITLE
Twozone extraction with BACKCORR=OMIT

### DIFF
--- a/calcos/extract.py
+++ b/calcos/extract.py
@@ -1486,7 +1486,23 @@ def extractSegmentTwozone(e_data, c_data, e_dq_data, ofd_header, segment,
                                                   xtract_info, centroid,
                                                   sdqflags)
     else:
+        # The background determined from the flt file (unit=counts/s)
         AV_E_BKG_i = np.zeros(ncols, dtype=np.float32)
+        # For each column, the total number of good background rows 
+        # between both background regions, as seen in the flt file 
+        nrows_e_bkg_i = np.ones(ncols, dtype=np.float32)
+        # This for the calculation of the error
+        # Even though BACKCORR is not performed, we still need the
+        # number of good rows in the background region to calculate
+        # the variance arrays
+        # nrows_c_bkg_i: For each column, the total number of good background rows 
+        # between both background regions, as seen in the counts file 
+        av_c_bkg_i, nrows_c_bkg_i = getBackground(c_data, e_dq_data,
+                                                  xtract_info, centroid,
+                                                  sdqflags)
+        # Since we do not want to perform BACKCORR, manually override the
+        # measured background counts and set to zero.
+        # The background determined from the counts file (unit=counts) 
         av_c_bkg_i = np.zeros(ncols, dtype=np.float32)
     e_data_sub = e_data - AV_E_BKG_i
     height = xtract_info.field("height")[0]

--- a/calcos/trace.py
+++ b/calcos/trace.py
@@ -473,7 +473,6 @@ def getBackground(data_array, goodcolumns, regions):
                                                          dtype=np.float64)[goodcolumns].mean(dtype=np.float64)
     nbkg2 = bg2stop - bg2start + 1
     bkg = (nbkg1*bkg1 + nbkg2*bkg2)/float(nbkg1 + nbkg2)
-    bkg = 0
     return bkg
 
 def getCentroid(data_array, goodcolumns, rowstart, rowstop, background=None):


### PR DESCRIPTION
CalCOS does work when using the TWOZONE extraction method and BACKCORR set to OMIT (see #183 ). These changes enable this combination to be used correctly. 

Testing was performed on dataset lcox08k2q. Both segment corrtags were calibrated like so:
1. v3.4.8, with XTRCTALG=TWOZONE and BACKCORR=PERFORM
2. v3.4.8, with XTRCTALG=TWOZONE and BACKCORR=OMIT
3. fork version, with XTRCTALG=TWOZONE and BACKCORR=PERFORM
4. fork version with XTRCTALG=TWOZONE and BACKCORR=OMIT

As expected, test case 2 failed. Cases 1 and 3 yielded identical x1ds. Case 4 did not crash, and produced a reasonable x1d. The only differences between cases 1/3 and 4 stem from the lack of a background correction in case 4. Using the difference between the NET arrays in cases 4 and 1/3, let's call this NET_DIFF, this is nearly identical to the BACKGROUND array in case 1/3. The maximum difference between NET_DIFF and case 1/3 BACKGROUND is on the order of e-5, and average difference is e-7 (see attached plot).

This seems to suggest that the only difference between case 1/3 & 4 is due to the absence of background correction in case 4, as expected. 

![comparison](https://github.com/spacetelescope/calcos/assets/2235188/91aa3bed-3f6a-4020-b169-a82453bc286f)
