### PR TITLE
use Numpy 2.0 release candidate

### DIFF
--- a/.github/workflows/python_testing.yml
+++ b/.github/workflows/python_testing.yml
@@ -29,7 +29,6 @@ jobs:
         TEST_BIGDATA: https://bytesalad.stsci.edu/artifactory
         lref: /grp/hst/cdbs/lref/
       envs: |
-        - linux: py39-xdist
         - linux: py310-xdist
         - linux: py311-xdist
         - macos: py311-xdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy>=5.0.4",
-    "numpy<2.0",
+    "numpy>=2.0.0rc2",
     "scipy",
     "stsci.tools>=4.0.0",
 ]
@@ -46,7 +46,7 @@ requires = [
     "setuptools>=42.0",
     "setuptools_scm[toml]>=3.4",
     "wheel",
-    "oldest-supported-numpy",
+    "numpy>=2.0.0rc2",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
ran regression tests (https://github.com/spacetelescope/RegressionTests/actions/runs/9453739674/job/26039817110#step:25:3340) and got several reference file differences (`AssertionError`s), as well as four of the following `TypeError`s:
```
E           TypeError: Cannot cast array data from dtype('float64') to dtype('float32') according to the rule 'safe'
```