### PR TITLE
Remove deprecation warning for astropy resolve_name under astropy 7.0.0

### DIFF
--- a/calcos/cosutil.py
+++ b/calcos/cosutil.py
@@ -518,7 +518,7 @@ def getTable(table, filter, extension=1,
 
         # Test for for wildcards in the table.
         wild = None
-        if isinstance(column, np.chararray):
+        if column.dtype.type == np.str_:
             wild = (column == STRING_WILDCARD)
         if wild is not None:
             selected = np.logical_or(selected, wild)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ pytest_plugins = ["pytest_ciwatson"]
 def pytest_report_header(config):
     import sys
     import warnings
-    from astropy.utils.introspection import resolve_name
+    import importlib
 
     s = "\nFull Python Version: \n{0}\n\n".format(sys.version)
 
@@ -24,7 +24,7 @@ def pytest_report_header(config):
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
-                module = resolve_name(module_name)
+                module = importlib.import_module(module_name)
         except ImportError:
             s += "{0}: not available\n".format(module_name)
         else:


### PR DESCRIPTION
by switching to importlib.import_module()