### PR TITLE
[build] remove maintainer password from PyPI publish workflow in lieu of trusted publisher attestation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,3 @@ jobs:
       sdist: true
       test_command: python -c "from calcos import ccos"
       upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
-    secrets:
-      pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [SCSB-199](https://jira.stsci.edu/browse/SCSB-199)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
- [ ] add a Trusted Publisher configuration to the PyPI project by visiting https://pypi.org/manage/project/calcos/settings/publishing/?provider=github&owner=spacetelescope&repository=calcos&workflow_filename=build.yml
- [x] remove `pypi_token` (STScI PyPI maintainer password) from build workflow
- [ ] wait for issue with reusable workflows to be resolved in `pypa/warehouse`