### PR TITLE
Remove dead links and replace with current regtest repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # CALCOS
 
-[![Jenkins CI](https://ssbjenkins.stsci.edu/job/STScI/job/calcos/job/master/badge/icon)](https://ssbjenkins.stsci.edu/job/STScI/job/calcos/job/master/)
-
 Calibration software for HST/COS.
 
-Nightly regression test results are available only from within the STScI
-network at this time.
-https://plwishmaster.stsci.edu:8081/job/RT/job/calcos/test_results_analyzer/
+Nightly regression test results are available only to members of the spacetelescope GitHub organization   
+https://github.com/spacetelescope/RegressionTests


### PR DESCRIPTION
plwishmaster is being retired,
The current location of RegressionTests is at https://github.com/spacetelescope/RegressionTests

Also removed the dead link to ssbjenkins