### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Calibration software for HST/COS.
 
-[![CalCOS Pytest](https://github.com/spacetelescope/calcos/actions/workflows/python_testing.yml/badge.svg)](https://github.com/spacetelescope/calcos/actions/workflows/python_testing.yml) [![test CalCOS](https://github.com/spacetelescope/RegressionTests/actions/workflows/calcos.yml/badge.svg)](https://github.com/spacetelescope/RegressionTests/actions/workflows/calcos.yml)
+[![CalCOS Pytest](https://github.com/spacetelescope/calcos/actions/workflows/python_testing.yml/badge.svg)](https://github.com/spacetelescope/calcos/actions/workflows/python_testing.yml)
+[![test CalCOS](https://github.com/spacetelescope/RegressionTests/actions/workflows/calcos.yml/badge.svg)](https://github.com/spacetelescope/RegressionTests/actions/workflows/calcos.yml)
 
 [Documentation](https://hst-docs.stsci.edu/cosdhb/chapter-3-cos-calibration)


### PR DESCRIPTION
The README file was pointing to the old Jenkins test server. This PR adds a badge for the nightly CI runs and links to the regression tests and documentation.