### PR TITLE
[SCSB-225] migrate `[tool.pytest.ini_options]` to native TOML

### DIFF
--- a/.github/workflows/python_testing.yml
+++ b/.github/workflows/python_testing.yml
@@ -29,7 +29,6 @@ jobs:
         TEST_BIGDATA: https://bytesalad.stsci.edu/artifactory
         lref: /grp/hst/cdbs/lref/
       envs: |
-        - linux: py39-xdist
         - linux: py310-xdist
         - linux: py311-xdist
         - linux: py312-xdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "calcos"
 description = "Calibration software for COS (Cosmic Origins Spectrograph)"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
   { name = "Phil Hodge", email = "help@stsci.edu" },
   { name = "Robert Jedrzejewski" },
@@ -26,7 +26,7 @@ calcos = "calcos:main"
 
 [project.optional-dependencies]
 docs = ["sphinx<7"]
-test = ["ci-watson", "pytest", "pytest-cov"]
+test = ["ci-watson", "pytest>=9.0", "pytest-cov"]
 
 [build-system]
 requires = [
@@ -48,8 +48,8 @@ calcos = ["pars/*", "*.help"]
 [tool.setuptools_scm]
 version_file = "calcos/version.py"
 
-[tool.pytest.ini_options]
-minversion = "3.0"
+[tool.pytest]
+minversion = "9.0"
 norecursedirs = ["build", "doc/build", "src"]
 junit_family = "xunit2"
 


### PR DESCRIPTION
Resolves [SCSB-225](https://jira.stsci.edu/browse/SCSB-225)

Pytest 9.0 includes a native TOML table `[tool.pytest]`, which we should use instead of `[tool.pytest.ini_options]`